### PR TITLE
AI-51: Create checklist creation page with rich text editor support

### DIFF
--- a/app/checklists/new/page.tsx
+++ b/app/checklists/new/page.tsx
@@ -6,13 +6,14 @@ import { ArrowLeftIcon, CheckCircledIcon } from '@radix-ui/react-icons';
 import Link from 'next/link';
 import SlateEditor from '../../components/editor/slate-editor';
 import { Descendant } from 'slate';
+import { ChecklistItemElement } from '../../components/editor/elements';
 
 export default function NewChecklistPage() {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   
   // Initial value for the Slate editor
-  const [editorValue, setEditorValue] = useState<Descendant[]>([
+  const [editorValue, setEditorValue] = useState<(ChecklistItemElement | Descendant)[]>([
     {
       type: 'checklist-item',
       checked: false,
@@ -82,7 +83,7 @@ export default function NewChecklistPage() {
           </Box>
           
           <Box>
-            <Text as="label" size="2" weight="bold" mb="2" display="block">
+            <Text as="label" size="2" weight="bold" className="mb-2 block">
               Checklist Items
             </Text>
             <Box className="border rounded-md p-2">

--- a/app/checklists/new/page.tsx
+++ b/app/checklists/new/page.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Button, Flex, Card, Text, Heading, Box, TextField, TextArea } from '@radix-ui/themes';
+import { ArrowLeftIcon, CheckCircledIcon } from '@radix-ui/react-icons';
+import Link from 'next/link';
+import SlateEditor from '../../components/editor/slate-editor';
+import { Descendant } from 'slate';
+
+export default function NewChecklistPage() {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  
+  // Initial value for the Slate editor
+  const [editorValue, setEditorValue] = useState<Descendant[]>([
+    {
+      type: 'checklist-item',
+      checked: false,
+      children: [{ text: 'My first checklist item' }],
+    },
+    {
+      type: 'checklist-item',
+      checked: false,
+      children: [{ text: 'Click to edit this item' }],
+    },
+    {
+      type: 'checklist-item',
+      checked: false,
+      children: [{ text: 'Add more items as needed' }],
+    },
+  ]);
+
+  const handleSave = () => {
+    // In a real app, this would save to a database
+    console.log({
+      title,
+      description,
+      items: editorValue,
+    });
+    
+    alert('Checklist saved! In a real app, this would persist the data.');
+  };
+
+  return (
+    <Flex direction="column" className="min-h-screen p-8">
+      <Box mb="4">
+        <Link href="/">
+          <Button variant="ghost" size="2">
+            <ArrowLeftIcon /> Back to Home
+          </Button>
+        </Link>
+      </Box>
+
+      <Heading size="7" mb="4">Create New Checklist</Heading>
+      
+      <Card className="max-w-3xl w-full mx-auto">
+        <Flex direction="column" gap="4" className="p-4">
+          <Box>
+            <Text as="label" size="2" weight="bold" htmlFor="title">
+              Title
+            </Text>
+            <TextField.Root 
+              size="3" 
+              id="title"
+              placeholder="Enter checklist title" 
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+          </Box>
+          
+          <Box>
+            <Text as="label" size="2" weight="bold" htmlFor="description">
+              Description (optional)
+            </Text>
+            <TextArea 
+              size="3" 
+              id="description"
+              placeholder="Enter checklist description" 
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </Box>
+          
+          <Box>
+            <Text as="label" size="2" weight="bold" mb="2" display="block">
+              Checklist Items
+            </Text>
+            <Box className="border rounded-md p-2">
+              <SlateEditor
+                value={editorValue}
+                onChange={setEditorValue}
+                placeholder="Add checklist items..."
+                className="min-h-[200px]"
+              />
+            </Box>
+          </Box>
+          
+          <Flex gap="3" mt="4" justify="end">
+            <Link href="/">
+              <Button variant="soft" color="gray">
+                Cancel
+              </Button>
+            </Link>
+            <Button onClick={handleSave}>
+              <CheckCircledIcon />
+              Save Checklist
+            </Button>
+          </Flex>
+        </Flex>
+      </Card>
+    </Flex>
+  );
+}

--- a/app/components/editor/elements.tsx
+++ b/app/components/editor/elements.tsx
@@ -42,6 +42,7 @@ export type ChecklistItemElement = {
   type: 'checklist-item';
   checked: boolean;
   children: (CustomText | EmptyText)[];
+  data: ChecklistItemData;
 };
 
 export type ChecklistElement = {
@@ -120,8 +121,6 @@ export const RenderElement = (props: CustomRenderElementProps): ReactElement => 
       return <ol {...attributes}>{children}</ol>;
     case 'list-item':
       return <li {...attributes}>{children}</li>;
-    case 'block-quote':
-      return <blockquote {...attributes}>{children}</blockquote>;
     case 'checklist-item':
       return (
         <div className="flex items-start" {...attributes}>
@@ -143,6 +142,8 @@ export const RenderElement = (props: CustomRenderElementProps): ReactElement => 
       );
     case 'checklist':
       return <div className="checklist" {...attributes}>{children}</div>;
+    case 'block-quote':
+      return <blockquote {...attributes}>{children}</blockquote>;
     default:
       return <p {...attributes}>{children}</p>;
   }

--- a/app/components/editor/elements.tsx
+++ b/app/components/editor/elements.tsx
@@ -4,7 +4,7 @@ import type { ReactElement } from 'react';
 import { useSlate } from 'slate-react';
 import { Transforms } from 'slate';
 
-import { EmptyText, CustomText, ChecklistItemData } from './types';
+import { EmptyText, CustomText, CustomEditor } from './types';
 
 // Define the types for our custom elements
 export type ParagraphElement = {
@@ -42,7 +42,6 @@ export type ChecklistItemElement = {
   type: 'checklist-item';
   checked: boolean;
   children: (CustomText | EmptyText)[];
-  data: ChecklistItemData;
 };
 
 export type ChecklistElement = {
@@ -93,7 +92,7 @@ const CheckboxComponent = ({ checked, onChange }: { checked: boolean; onChange: 
 // Render element component
 export const RenderElement = (props: CustomRenderElementProps): ReactElement => {
   const { attributes, children, element } = props;
-  const editor = useSlate();
+  const editor = useSlate() as CustomEditor;
 
   switch (element.type) {
     case 'paragraph':
@@ -128,7 +127,7 @@ export const RenderElement = (props: CustomRenderElementProps): ReactElement => 
             checked={element.checked} 
             onChange={() => {
               const path = ReactEditor.findPath(editor, element);
-              Transforms.setNodes(
+              Transforms.setNodes<ChecklistItemElement>(
                 editor,
                 { checked: !element.checked },
                 { at: path }

--- a/app/components/editor/elements.tsx
+++ b/app/components/editor/elements.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { RenderElementProps } from 'slate-react';
+import { RenderElementProps, ReactEditor } from 'slate-react';
 import type { ReactElement } from 'react';
+import { useSlate } from 'slate-react';
+import { Transforms } from 'slate';
 
-import { EmptyText, CustomText } from './types';
+import { EmptyText, CustomText, ChecklistItemData } from './types';
 
 // Define the types for our custom elements
 export type ParagraphElement = {
@@ -36,6 +38,17 @@ export type BlockQuoteElement = {
   children: (CustomText | EmptyText)[];
 };
 
+export type ChecklistItemElement = {
+  type: 'checklist-item';
+  checked: boolean;
+  children: (CustomText | EmptyText)[];
+};
+
+export type ChecklistElement = {
+  type: 'checklist';
+  children: ChecklistItemElement[];
+};
+
 // Union type for all custom elements
 export type CustomElement = 
   | ParagraphElement 
@@ -43,16 +56,43 @@ export type CustomElement =
   | ListItemElement 
   | BulletedListElement 
   | NumberedListElement 
-  | BlockQuoteElement;
+  | BlockQuoteElement
+  | ChecklistItemElement
+  | ChecklistElement;
 
 // Type for render element props with our custom element type
 export type CustomRenderElementProps = RenderElementProps & {
   element: CustomElement;
 };
 
+// Checkbox component for checklist items
+const CheckboxComponent = ({ checked, onChange }: { checked: boolean; onChange: () => void }) => {
+  return (
+    <span 
+      contentEditable={false} 
+      className="mr-2 inline-flex"
+      onClick={(e) => {
+        e.preventDefault();
+        onChange();
+      }}
+    >
+      <input 
+        type="checkbox" 
+        checked={checked} 
+        onChange={(e) => {
+          e.preventDefault();
+          onChange();
+        }}
+        className="mr-1 h-4 w-4 cursor-pointer"
+      />
+    </span>
+  );
+};
+
 // Render element component
 export const RenderElement = (props: CustomRenderElementProps): ReactElement => {
   const { attributes, children, element } = props;
+  const editor = useSlate();
 
   switch (element.type) {
     case 'paragraph':
@@ -82,6 +122,27 @@ export const RenderElement = (props: CustomRenderElementProps): ReactElement => 
       return <li {...attributes}>{children}</li>;
     case 'block-quote':
       return <blockquote {...attributes}>{children}</blockquote>;
+    case 'checklist-item':
+      return (
+        <div className="flex items-start" {...attributes}>
+          <CheckboxComponent 
+            checked={element.checked} 
+            onChange={() => {
+              const path = ReactEditor.findPath(editor, element);
+              Transforms.setNodes(
+                editor,
+                { checked: !element.checked },
+                { at: path }
+              );
+            }}
+          />
+          <span className={element.checked ? "line-through text-gray-500" : ""}>
+            {children}
+          </span>
+        </div>
+      );
+    case 'checklist':
+      return <div className="checklist" {...attributes}>{children}</div>;
     default:
       return <p {...attributes}>{children}</p>;
   }

--- a/app/components/editor/toolbar.tsx
+++ b/app/components/editor/toolbar.tsx
@@ -9,6 +9,7 @@ import {
   toggleHeading,
   toggleList,
   toggleBlockQuote,
+  toggleChecklist,
   isMarkActive,
   isBlockActive
 } from './utils';
@@ -115,6 +116,12 @@ const Toolbar: React.FC<ToolbarProps> = ({ className = '', selection }) => {
         icon="❝"
         onClick={() => toggleBlockQuote(editor)}
         isActive={isBlockActive(editor, 'block-quote')}
+      />
+      <ToolbarButton
+        format="checklist-item"
+        icon="☑"
+        onClick={() => toggleChecklist(editor)}
+        isActive={isBlockActive(editor, 'checklist-item')}
       />
     </div>
   );

--- a/app/components/editor/types.ts
+++ b/app/components/editor/types.ts
@@ -1,4 +1,5 @@
 import { Editor } from 'slate';
+import { ReactEditor } from 'slate-react';
 
 // Custom text types
 export interface CustomText {
@@ -14,7 +15,7 @@ export type EmptyText = {
 };
 
 // Custom editor type
-export type CustomEditor = Editor & {
+export type CustomEditor = Editor & ReactEditor & {
   // Add any custom methods here if needed
 };
 

--- a/app/components/editor/types.ts
+++ b/app/components/editor/types.ts
@@ -17,3 +17,8 @@ export type EmptyText = {
 export type CustomEditor = Editor & {
   // Add any custom methods here if needed
 };
+
+// Additional type for checklist items
+export interface ChecklistItemData {
+  checked: boolean;
+}

--- a/app/components/editor/utils.tsx
+++ b/app/components/editor/utils.tsx
@@ -2,6 +2,7 @@ import { Editor, Transforms, Element as SlateElement } from 'slate';
 import { RenderLeafProps } from 'slate-react';
 import { CustomText } from './types';
 import React, { ReactElement } from 'react';
+import { ChecklistItemElement, ParagraphElement } from './elements';
 
 // Type for custom leaf props
 interface CustomRenderLeafProps extends RenderLeafProps {
@@ -135,10 +136,16 @@ export const toggleChecklist = (editor: Editor) => {
   });
 
   // Set the nodes to checklist items or paragraphs
-  Transforms.setNodes(editor, {
-    type: isActive ? 'paragraph' : 'checklist-item',
-    checked: isActive ? undefined : false,
-  });
+  if (isActive) {
+    Transforms.setNodes<ParagraphElement>(editor, {
+      type: 'paragraph',
+    });
+  } else {
+    Transforms.setNodes<ChecklistItemElement>(editor, {
+      type: 'checklist-item',
+      checked: false,
+    });
+  }
 
   // If we're creating checklist items, wrap them in a checklist container
   if (!isActive) {

--- a/app/components/editor/utils.tsx
+++ b/app/components/editor/utils.tsx
@@ -115,6 +115,38 @@ export const toggleList = (editor: Editor, format: 'bulleted-list' | 'numbered-l
   toggleBlock(editor, format);
 export const toggleBlockQuote = (editor: Editor) => toggleBlock(editor, 'block-quote');
 
+// Toggle checklist item
+export const toggleChecklist = (editor: Editor) => {
+  const isActive = isBlockActive(editor, 'checklist-item');
+  
+  // Unwrap any list items if needed
+  Transforms.unwrapNodes(editor, {
+    match: (n) => {
+      if (!Editor.isEditor(n) && SlateElement.isElement(n)) {
+        // Need to cast through unknown first to avoid TypeScript errors
+        const element = n as unknown as { type?: string };
+        if (element.type && ['bulleted-list', 'numbered-list', 'checklist'].includes(element.type)) {
+          return true;
+        }
+      }
+      return false;
+    },
+    split: true,
+  });
+
+  // Set the nodes to checklist items or paragraphs
+  Transforms.setNodes(editor, {
+    type: isActive ? 'paragraph' : 'checklist-item',
+    checked: isActive ? undefined : false,
+  });
+
+  // If we're creating checklist items, wrap them in a checklist container
+  if (!isActive) {
+    const block = { type: 'checklist', children: [] };
+    Transforms.wrapNodes(editor, block);
+  }
+};
+
 // Leaf rendering
 export const RenderLeaf = (props: CustomRenderLeafProps): ReactElement => {
   const { attributes, children, leaf } = props;

--- a/app/globals.css
+++ b/app/globals.css
@@ -22,3 +22,77 @@ body {
   color: var(--foreground);
   background: var(--background);
 }
+
+/* Slate editor customization */
+.slate-editor {
+  min-height: 150px;
+}
+
+.toolbar {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+  border: 1px solid #e2e2e2;
+  border-radius: 0.25rem;
+  background-color: #f8f8f8;
+}
+
+.dark-theme .toolbar {
+  border-color: #333;
+  background-color: #222;
+}
+
+.toolbar-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 0.25rem;
+  background-color: transparent;
+  cursor: pointer;
+  transition: background-color 0.1s ease;
+}
+
+.toolbar-button:hover {
+  background-color: #efefef;
+}
+
+.dark-theme .toolbar-button:hover {
+  background-color: #333;
+}
+
+.toolbar-button.active {
+  background-color: #e5e5e5;
+  color: #0070f3;
+}
+
+.dark-theme .toolbar-button.active {
+  background-color: #333;
+  color: #3b82f6;
+}
+
+.toolbar-divider {
+  width: 1px;
+  background-color: #e2e2e2;
+  margin: 0 0.25rem;
+}
+
+.dark-theme .toolbar-divider {
+  background-color: #333;
+}
+
+/* Checklist styling */
+.checklist {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.checklist input[type="checkbox"] {
+  cursor: pointer;
+  width: 1rem;
+  height: 1rem;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,12 @@
 import Image from "next/image";
 import { Button, Flex, Card, Text, Heading, Box, Tabs, Badge, Tooltip } from '@radix-ui/themes';
-import { InfoCircledIcon, MoonIcon, SunIcon } from '@radix-ui/react-icons';
+import { InfoCircledIcon, MoonIcon, SunIcon, PlusCircledIcon } from '@radix-ui/react-icons';
+import Link from 'next/link';
 
 export default function Home() {
   return (
     <Flex direction="column" align="center" justify="center" className="min-h-screen p-8">
-      <Heading size="7" className="mb-8">Hello world with Radix UI!</Heading>
+      <Heading size="7" className="mb-8">Checklist App with Radix UI</Heading>
       
       <Card className="mb-8 max-w-md">
         <Flex direction="column" gap="4" align="center">
@@ -43,6 +44,7 @@ export default function Home() {
               <Box className="p-4">
                 <Text as="p" size="2">
                   This app demonstrates the integration of Radix UI with Next.js and Tailwind CSS.
+                  Create checklists with our rich text editor that supports formatting and checkbox items.
                   The theme automatically adapts to your system preferences.
                 </Text>
                 
@@ -67,16 +69,29 @@ export default function Home() {
         </Flex>
       </Card>
       
-      <Tooltip content="Click to send an email">
-        <Button size="3" variant="solid" asChild>
-          <a href="mailto:maxim@sacredgraph.com?subject=Hello%20from%20AI">
-            <Flex gap="1" align="center">
-              <InfoCircledIcon />
-              Contact Me
-            </Flex>
-          </a>
-        </Button>
-      </Tooltip>
+      <Flex gap="3" mt="4">
+        <Tooltip content="Create a new checklist">
+          <Button size="3" variant="solid" color="green" asChild>
+            <Link href="/checklists/new">
+              <Flex gap="1" align="center">
+                <PlusCircledIcon />
+                New Checklist
+              </Flex>
+            </Link>
+          </Button>
+        </Tooltip>
+
+        <Tooltip content="Click to send an email">
+          <Button size="3" variant="solid" asChild>
+            <a href="mailto:maxim@sacredgraph.com?subject=Hello%20from%20AI">
+              <Flex gap="1" align="center">
+                <InfoCircledIcon />
+                Contact Me
+              </Flex>
+            </a>
+          </Button>
+        </Tooltip>
+      </Flex>
     </Flex>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,12 +19,27 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.2.0",
+        "tailwindcss": "^4",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -2294,6 +2309,243 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.0.9.tgz",
+      "integrity": "sha512-tOJvdI7XfJbARYhxX+0RArAhmuDcczTC46DGCEziqxzzbIaPnfYaIyRT31n4u8lROrsO7Q6u/K9bmQHL2uL1bQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "enhanced-resolve": "^5.18.1",
+        "jiti": "^2.4.2",
+        "tailwindcss": "4.0.9"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.0.9.tgz",
+      "integrity": "sha512-eLizHmXFqHswJONwfqi/WZjtmWZpIalpvMlNhTM99/bkHtUs6IqgI1XQ0/W5eO2HiRQcIlXUogI2ycvKhVLNcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.0.9",
+        "@tailwindcss/oxide-darwin-arm64": "4.0.9",
+        "@tailwindcss/oxide-darwin-x64": "4.0.9",
+        "@tailwindcss/oxide-freebsd-x64": "4.0.9",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.0.9",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.0.9",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.0.9",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.0.9",
+        "@tailwindcss/oxide-linux-x64-musl": "4.0.9",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.0.9",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.0.9"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.0.9.tgz",
+      "integrity": "sha512-YBgy6+2flE/8dbtrdotVInhMVIxnHJPbAwa7U1gX4l2ThUIaPUp18LjB9wEH8wAGMBZUb//SzLtdXXNBHPUl6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.0.9.tgz",
+      "integrity": "sha512-pWdl4J2dIHXALgy2jVkwKBmtEb73kqIfMpYmcgESr7oPQ+lbcQ4+tlPeVXaSAmang+vglAfFpXQCOvs/aGSqlw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.0.9.tgz",
+      "integrity": "sha512-4Dq3lKp0/C7vrRSkNPtBGVebEyWt9QPPlQctxJ0H3MDyiQYvzVYf8jKow7h5QkWNe8hbatEqljMj/Y0M+ERYJg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.0.9.tgz",
+      "integrity": "sha512-k7U1RwRODta8x0uealtVt3RoWAWqA+D5FAOsvVGpYoI6ObgmnzqWW6pnVwz70tL8UZ/QXjeMyiICXyjzB6OGtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.0.9.tgz",
+      "integrity": "sha512-NDDjVweHz2zo4j+oS8y3KwKL5wGCZoXGA9ruJM982uVJLdsF8/1AeKvUwKRlMBpxHt1EdWJSAh8a0Mfhl28GlQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.0.9.tgz",
+      "integrity": "sha512-jk90UZ0jzJl3Dy1BhuFfRZ2KP9wVKMXPjmCtY4U6fF2LvrjP5gWFJj5VHzfzHonJexjrGe1lMzgtjriuZkxagg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.0.9.tgz",
+      "integrity": "sha512-3eMjyTC6HBxh9nRgOHzrc96PYh1/jWOwHZ3Kk0JN0Kl25BJ80Lj9HEvvwVDNTgPg154LdICwuFLuhfgH9DULmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.0.9.tgz",
+      "integrity": "sha512-v0D8WqI/c3WpWH1kq/HP0J899ATLdGZmENa2/emmNjubT0sWtEke9W9+wXeEoACuGAhF9i3PO5MeyditpDCiWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.0.9.tgz",
+      "integrity": "sha512-Kvp0TCkfeXyeehqLJr7otsc4hd/BUPfcIGrQiwsTVCfaMfjQZCG7DjI+9/QqPZha8YapLA9UoIcUILRYO7NE1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.0.9.tgz",
+      "integrity": "sha512-m3+60T/7YvWekajNq/eexjhV8z10rswcz4BC9bioJ7YaN+7K8W2AmLmG0B79H14m6UHE571qB0XsPus4n0QVgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.0.9.tgz",
+      "integrity": "sha512-dpc05mSlqkwVNOUjGu/ZXd5U1XNch1kHFJ4/cHkZFvaW1RzbHmRt24gvM8/HC6IirMxNarzVw4IXVtvrOoZtxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.0.9.tgz",
+      "integrity": "sha512-BT/E+pdMqulavEAVM5NCpxmGEwHiLDPpkmg/c/X25ZBW+izTe+aZ+v1gf/HXTrihRoCxrUp5U4YyHsBTzspQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.0.9",
+        "@tailwindcss/oxide": "4.0.9",
+        "lightningcss": "^1.29.1",
+        "postcss": "^8.4.41",
+        "tailwindcss": "4.0.9"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -3241,6 +3493,12 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/direction": {
       "version": "1.0.4",
@@ -4851,8 +5109,6 @@
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -4969,6 +5225,245 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.1.tgz",
+      "integrity": "sha512-FmGoeD4S05ewj+AkhTY+D+myDvXI6eL27FjHIjoyUkO/uw7WZD1fBVs0QxeYWa7E17CUHJaYX/RUGISCtcrG4Q==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-darwin-arm64": "1.29.1",
+        "lightningcss-darwin-x64": "1.29.1",
+        "lightningcss-freebsd-x64": "1.29.1",
+        "lightningcss-linux-arm-gnueabihf": "1.29.1",
+        "lightningcss-linux-arm64-gnu": "1.29.1",
+        "lightningcss-linux-arm64-musl": "1.29.1",
+        "lightningcss-linux-x64-gnu": "1.29.1",
+        "lightningcss-linux-x64-musl": "1.29.1",
+        "lightningcss-win32-arm64-msvc": "1.29.1",
+        "lightningcss-win32-x64-msvc": "1.29.1"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.1.tgz",
+      "integrity": "sha512-HtR5XJ5A0lvCqYAoSv2QdZZyoHNttBpa5EP9aNuzBQeKGfbyH5+UipLWvVzpP4Uml5ej4BYs5I9Lco9u1fECqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.1.tgz",
+      "integrity": "sha512-k33G9IzKUpHy/J/3+9MCO4e+PzaFblsgBjSGlpAaFikeBFm8B/CkO3cKU9oI4g+fjS2KlkLM/Bza9K/aw8wsNA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.1.tgz",
+      "integrity": "sha512-0SUW22fv/8kln2LnIdOCmSuXnxgxVC276W5KLTwoehiO0hxkacBxjHOL5EtHD8BAXg2BvuhsJPmVMasvby3LiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.1.tgz",
+      "integrity": "sha512-sD32pFvlR0kDlqsOZmYqH/68SqUMPNj+0pucGxToXZi4XZgZmqeX/NkxNKCPsswAXU3UeYgDSpGhu05eAufjDg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.1.tgz",
+      "integrity": "sha512-0+vClRIZ6mmJl/dxGuRsE197o1HDEeeRk6nzycSy2GofC2JsY4ifCRnvUWf/CUBQmlrvMzt6SMQNMSEu22csWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.1.tgz",
+      "integrity": "sha512-UKMFrG4rL/uHNgelBsDwJcBqVpzNJbzsKkbI3Ja5fg00sgQnHw/VrzUTEc4jhZ+AN2BvQYz/tkHu4vt1kLuJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.1.tgz",
+      "integrity": "sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.1.tgz",
+      "integrity": "sha512-L0Tx0DtaNUTzXv0lbGCLB/c/qEADanHbu4QdcNOXLIe1i8i22rZRpbT3gpWYsCh9aSL9zFujY/WmEXIatWvXbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.1.tgz",
+      "integrity": "sha512-QoOVnkIEFfbW4xPi+dpdft/zAKmgLgsRHfJalEPYuJDOWf7cLQzYg0DEh8/sn737FaeMJxHZRc1oBreiwZCjog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.1.tgz",
+      "integrity": "sha512-NygcbThNBe4JElP+olyTI/doBNGJvLs3bFCRPdvuCcxZCcCZ71B858IHpdm7L1btZex0FvCmM17FK98Y9MRy1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/locate-path": {
@@ -5441,6 +5936,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.8",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -6347,6 +6871,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.9.tgz",
+      "integrity": "sha512-12laZu+fv1ONDRoNR9ipTOpUD7RN9essRVkX36sjxuRUInpN7hIiHN4lBd/SIFjbISvnXzp8h/hXzmU8SQQYhw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.1",


### PR DESCRIPTION
## Summary
- Created a new route at /checklists/new for creating and managing checklists
- Extended the Slate editor to support checklist items with toggle functionality
- Added a user-friendly form for creating checklists with title, description, and items
- Added navigation from the home page to the checklist creation page

## Test plan
- Verify the "New Checklist" button appears on the home page and navigates to /checklists/new
- Test the checklist creation form with various inputs
- Verify the checklist items can be toggled on/off
- Check that the editor toolbar functions properly for formatting text
- Confirm the interface works in both light and dark modes

🤖 Generated with [Claude Code](https://claude.ai/code)